### PR TITLE
Patch format-exception-only too

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,10 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**1.0.0rc5**
+
+- Patch for ``traceback.TracebackException.format_exception_only()`` (PR by Zac Hatfield-Dodds)
+
 **1.0.0rc4**
 
 - Update `PEP 678`_ support to use ``.add_note()`` and ``__notes__`` (PR by Zac Hatfield-Dodds)

--- a/src/exceptiongroup/_formatting.py
+++ b/src/exceptiongroup/_formatting.py
@@ -29,7 +29,7 @@ def _format_final_exc_line(etype, value):
     if value is None or not valuestr:
         line = "%s\n" % etype
     else:
-        line = "%s: %s\n" % (etype, valuestr)
+        line = "{}: {}\n".format(etype, valuestr)
     return line
 
 

--- a/src/exceptiongroup/_formatting.py
+++ b/src/exceptiongroup/_formatting.py
@@ -30,6 +30,7 @@ def _format_final_exc_line(etype, value):
         line = f"{etype}\n"
     else:
         line = f"{etype}: {valuestr}\n"
+
     return line
 
 

--- a/src/exceptiongroup/_formatting.py
+++ b/src/exceptiongroup/_formatting.py
@@ -147,6 +147,7 @@ def traceback_exception_format_exception_only(self):
         yield _format_final_exc_line(stype, self._str)
     else:
         yield from self._format_syntax_error(stype)
+
     if isinstance(self.__notes__, collections.abc.Sequence):
         for note in self.__notes__:
             note = _safe_string(note, "note")

--- a/src/exceptiongroup/_formatting.py
+++ b/src/exceptiongroup/_formatting.py
@@ -27,9 +27,9 @@ _context_message = (
 def _format_final_exc_line(etype, value):
     valuestr = _safe_string(value, "exception")
     if value is None or not valuestr:
-        line = "%s\n" % etype
+        line = f"{etype}\n"
     else:
-        line = "{}: {}\n".format(etype, valuestr)
+        line = f"{etype}: {valuestr}\n"
     return line
 
 

--- a/src/exceptiongroup/_formatting.py
+++ b/src/exceptiongroup/_formatting.py
@@ -4,6 +4,7 @@
 # library
 from __future__ import annotations
 
+import collections.abc
 import sys
 import textwrap
 import traceback
@@ -21,6 +22,22 @@ _cause_message = (
 _context_message = (
     "\nDuring handling of the above exception, another exception occurred:\n\n"
 )
+
+
+def _format_final_exc_line(etype, value):
+    valuestr = _safe_string(value, "exception")
+    if value is None or not valuestr:
+        line = "%s\n" % etype
+    else:
+        line = "%s: %s\n" % (etype, valuestr)
+    return line
+
+
+def _safe_string(value, what, func=str):
+    try:
+        return func(value)
+    except BaseException:
+        return f"<{what} {func.__name__}() failed>"
 
 
 def traceback_exception_init(
@@ -104,6 +121,39 @@ class _ExceptionPrintContext:
                 yield textwrap.indent(text, indent_str, lambda line: True)
 
 
+def traceback_exception_format_exception_only(self):
+    """Format the exception part of the traceback.
+    The return value is a generator of strings, each ending in a newline.
+    Normally, the generator emits a single string; however, for
+    SyntaxError exceptions, it emits several lines that (when
+    printed) display detailed information about where the syntax
+    error occurred.
+    The message indicating which exception occurred is always the last
+    string in the output.
+    """
+    if self.exc_type is None:
+        yield traceback._format_final_exc_line(None, self._str)
+        return
+
+    stype = self.exc_type.__qualname__
+    smod = self.exc_type.__module__
+    if smod not in ("__main__", "builtins"):
+        if not isinstance(smod, str):
+            smod = "<unknown>"
+        stype = smod + "." + stype
+
+    if not issubclass(self.exc_type, SyntaxError):
+        yield _format_final_exc_line(stype, self._str)
+    else:
+        yield from self._format_syntax_error(stype)
+    if isinstance(self.__notes__, collections.abc.Sequence):
+        for note in self.__notes__:
+            note = _safe_string(note, "note")
+            yield from [line + "\n" for line in note.split("\n")]
+    elif self.__notes__ is not None:
+        yield _safe_string(self.__notes__, "__notes__", func=repr)
+
+
 def traceback_exception_format(self, *, chain=True, _ctx=None):
     if _ctx is None:
         _ctx = _ExceptionPrintContext()
@@ -135,12 +185,6 @@ def traceback_exception_format(self, *, chain=True, _ctx=None):
                 yield from _ctx.emit("Traceback (most recent call last):\n")
                 yield from _ctx.emit(exc.stack.format())
             yield from _ctx.emit(exc.format_exception_only())
-            for note in exc.__notes__:
-                try:
-                    msg = str(note)
-                except BaseException:
-                    msg = "<note str() failed>"
-                yield from _ctx.emit(msg + "\n")
         elif _ctx.exception_group_depth > max_group_depth:
             # exception group, but depth exceeds limit
             yield from _ctx.emit(f"... (max_group_depth is {max_group_depth})\n")
@@ -158,12 +202,6 @@ def traceback_exception_format(self, *, chain=True, _ctx=None):
                 yield from _ctx.emit(exc.stack.format())
 
             yield from _ctx.emit(exc.format_exception_only())
-            for note in exc.__notes__:
-                try:
-                    msg = str(note)
-                except BaseException:
-                    msg = "<note str() failed>"
-                yield from _ctx.emit(msg + "\n")
             num_excs = len(exc.exceptions)
             if num_excs <= max_group_width:
                 n = num_excs
@@ -217,6 +255,12 @@ traceback.TracebackException.__init__ = (  # type: ignore[assignment]
 traceback_exception_original_format = traceback.TracebackException.format
 traceback.TracebackException.format = (  # type: ignore[assignment]
     traceback_exception_format
+)
+traceback_exception_original_format_exception_only = (
+    traceback.TracebackException.format_exception_only
+)
+traceback.TracebackException.format_exception_only = (  # type: ignore[assignment]
+    traceback_exception_format_exception_only
 )
 
 if sys.excepthook is sys.__excepthook__:

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -54,3 +54,56 @@ def test_formatting(capsys):
     +------------------------------------
 """
     )
+
+
+def test_formatting_exception_only(capsys):
+    exceptions = []
+    try:
+        raise ValueError("foo")
+    except ValueError as exc:
+        exceptions.append(exc)
+
+    try:
+        raise RuntimeError("bar")
+    except RuntimeError as exc:
+        exc.__notes__ = ["Note from bar handler"]
+        exceptions.append(exc)
+
+    try:
+        raise ExceptionGroup("test message", exceptions)
+    except ExceptionGroup as exc:
+        exc.add_note("Displays notes attached to the group too")
+        sys.excepthook(type(exc), exc, exc.__traceback__)
+
+    lineno = test_formatting_exception_only.__code__.co_firstlineno
+    if sys.version_info >= (3, 11):
+        module_prefix = ""
+        underline1 = "\n  |     " + "^" * 48
+        underline2 = "\n    |     " + "^" * 23
+        underline3 = "\n    |     " + "^" * 25
+    else:
+        module_prefix = "exceptiongroup."
+        underline1 = underline2 = underline3 = ""
+
+    output = capsys.readouterr().err
+    assert output == (
+        f"""\
+  + Exception Group Traceback (most recent call last):
+  |   File "{__file__}", line {lineno + 14}, in test_formatting_exception_only
+  |     raise ExceptionGroup("test message", exceptions){underline1}
+  | {module_prefix}ExceptionGroup: test message (2 sub-exceptions)
+  | Displays notes attached to the group too
+  +-+---------------- 1 ----------------
+    | Traceback (most recent call last):
+    |   File "{__file__}", line {lineno + 3}, in test_formatting_exception_only
+    |     raise ValueError("foo"){underline2}
+    | ValueError: foo
+    +---------------- 2 ----------------
+    | Traceback (most recent call last):
+    |   File "{__file__}", line {lineno + 8}, in test_formatting_exception_only
+    |     raise RuntimeError("bar"){underline3}
+    | RuntimeError: bar
+    | Note from bar handler
+    +------------------------------------
+"""
+    )


### PR DESCRIPTION
Fixes #7, ensuring that e.g. Pytest's traceback formatting (which uses `format_exception_only()`) will also show notes.