### PR TITLE
Patch sys.unraisablehook to format exception groups

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,10 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Patch ``sys.unraisablehook`` to properly format exceptiongroups
+
 **1.0.0rc8**
 
 - Don't monkey patch anything if ``sys.excepthook`` has been altered

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -4,7 +4,6 @@ import sys
 import pytest
 
 from exceptiongroup import ExceptionGroup
-from exceptiongroup._formatting import exceptiongroup_unraisablehook
 
 
 def test_formatting(capsys):
@@ -128,8 +127,14 @@ SyntaxError: invalid syntax
 @pytest.mark.skipif(
     sys.version_info < (3, 8), reason="sys.unraisablehook was added in Python 3.8"
 )
+@pytest.mark.skipif(
+    sys.version_info >= (3, 11),
+    reason="sys.unraisablehook is not touched on Python >= 3.11",
+)
 def test_unraisablehook(capsys, monkeypatch):
-    # Pytest overrides sys.unraisablehook so we temporarily override that here
+    # Pytest overrides sys.unraisablehook, so we temporarily override that here
+    from exceptiongroup._formatting import exceptiongroup_unraisablehook
+
     monkeypatch.setattr(sys, "unraisablehook", exceptiongroup_unraisablehook)
 
     class Foo:


### PR DESCRIPTION
Whether this should be merged or not depends on the resolution of upstream issue (https://github.com/python/cpython/issues/95572).

Fixes #18.