### PR TITLE
Specify a minimum tox version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,8 @@ legacy_tox_ini = """
 envlist = py37, py38, py39, py310, py311, pypy3
 skip_missing_interpreters = true
 isolated_build = true
+# Need tox 3.18.1 or newer due to https://github.com/tox-dev/tox/issues/1344
+minversion = 3.18.1
 
 [testenv]
 extras = test


### PR DESCRIPTION
Versions of tox before 3.18.1 are incompatible [due to a bug in tox](https://github.com/tox-dev/tox/issues/1344).

Here is what the error looks like:
```
.package create: /data/jranieri/chisel_work/exceptiongroup/.tox/.package
.package installdeps: flit_scm
ERROR: invocation failed (exit code 1), logfile: /data/jranieri/chisel_work/exceptiongroup/.tox/.package/log/.package-2.log
================================================================================================== log start ===================================================================================================
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/tox/helper/build_requires.py", line 7, in <module>
    backend = __import__(backend_spec, fromlist=[None])
  File "<frozen importlib._bootstrap>", line 1033, in _handle_fromlist
TypeError: Item in ``from list'' must be str, not NoneType

=================================================================================================== log end ====================================================================================================
ERROR: FAIL could not package project - v = InvocationError('/data/jranieri/chisel_work/exceptiongroup/.tox/.package/bin/python /usr/lib/python3/dist-packages/tox/helper/build_requires.py flit_scm buildapi', 1)
```

Specifying a minimum version of tox will make older versions of tox create a provisioning environment that contains a newer, compatible, version of tox -- making everything transparently "just work".