### PR TITLE
Work around CPython bug in `HTTPError`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,12 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**UNRELEASED**
+
+- Workaround for [CPython issue #98778](https://github.com/python/cpython/issues/98778),
+  ``urllib.error.HTTPError(..., fp=None)`` raises ``KeyError`` on unknown attribute access,
+  on affected Python versions.  (PR by Zac Hatfield-Dodds)
+
 **1.1.0**
 
 - Backported upstream fix for gh-99553 (custom subclasses of ``BaseExceptionGroup`` that

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -8,6 +8,7 @@ from _pytest.fixtures import SubRequest
 from _pytest.monkeypatch import MonkeyPatch
 
 from exceptiongroup import ExceptionGroup
+from exceptiongroup._formatting import PatchedTracebackException
 
 
 def raise_excgroup() -> NoReturn:
@@ -532,9 +533,6 @@ def test_bug_suggestions_attributeerror_no_obj(
 
 
 def test_works_around_httperror_bug():
-    try:
-        # See https://github.com/python/cpython/issues/98778 in Python <= 3.9
-        HTTPError("url", 405, "METHOD NOT ALLOWED", None, None)
-    except Exception as exc:
-        # All we're testing for here is that it doesn't crash
-        sys.excepthook(type(exc), exc, exc.__traceback__)
+    # See https://github.com/python/cpython/issues/98778 in Python <= 3.9
+    err = HTTPError("url", 405, "METHOD NOT ALLOWED", None, None)
+    PatchedTracebackException(type(err), err, None)

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,4 +1,5 @@
 import sys
+import traceback
 from typing import NoReturn
 from urllib.error import HTTPError
 
@@ -8,7 +9,6 @@ from _pytest.fixtures import SubRequest
 from _pytest.monkeypatch import MonkeyPatch
 
 from exceptiongroup import ExceptionGroup
-from exceptiongroup._formatting import PatchedTracebackException
 
 
 def raise_excgroup() -> NoReturn:
@@ -535,4 +535,4 @@ def test_bug_suggestions_attributeerror_no_obj(
 def test_works_around_httperror_bug():
     # See https://github.com/python/cpython/issues/98778 in Python <= 3.9
     err = HTTPError("url", 405, "METHOD NOT ALLOWED", None, None)
-    PatchedTracebackException(type(err), err, None)
+    traceback.TracebackException(type(err), err, None)

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,5 +1,6 @@
 import sys
 from typing import NoReturn
+from urllib.error import HTTPError
 
 import pytest
 from _pytest.capture import CaptureFixture
@@ -528,3 +529,12 @@ def test_bug_suggestions_attributeerror_no_obj(
         print_exception(e)  # does not crash
         output = capsys.readouterr().err
         assert "NamedAttributeError" in output
+
+
+def test_works_around_httperror_bug():
+    try:
+        # See https://github.com/python/cpython/issues/98778 in Python <= 3.9
+        HTTPError("url", 405, "METHOD NOT ALLOWED", None, None)
+    except Exception as exc:
+        # All we're testing for here is that it doesn't crash
+        sys.excepthook(type(exc), exc, exc.__traceback__)


### PR DESCRIPTION
Workaround for https://github.com/python/cpython/issues/98778 (aka https://github.com/python/cpython/issues/90113), in order to fix https://github.com/pytest-dev/pytest/issues/10797.

This is a little ugly but I thought we'd prefer to keep it tightly scoped rather than suppressing _anything_ raised by `getattr()`.