### PR TITLE
Include tests in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ test = [
 ]
 
 [tool.flit.sdist]
+include = [
+    "tests",
+]
 exclude = [
     ".github/*",
     ".gitignore",


### PR DESCRIPTION
Include tests when building sdist archives, in order to make them a suitable source for distributions.