### PR TITLE
catch now raises typeerror on async handler

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Version history
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **UNRELEASED**
-- `catch` now raises a `TypeError` if passed an async exception handler instead of just giving a `RuntimeWarning` about the coroutine never being awaited. (#66, PR by John Litborn)
+- `catch()` now raises a `TypeError` if passed an async exception handler instead of
+  just giving a `RuntimeWarning` about the coroutine never being awaited. (#66, PR by
+  John Litborn)
 
 **1.1.2**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**1.1.3**
+- `catch` now raises a `TypeError` if passed an async exception handler instead of just giving a `RuntimeWarning` about the coroutine never being awaited. (#66, PR by John Litborn)
+
 **1.1.2**
 
 - Changed handling of exceptions in exception group handler callbacks to not wrap a

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
-**1.1.3**
+**UNRELEASED**
 - `catch` now raises a `TypeError` if passed an async exception handler instead of just giving a `RuntimeWarning` about the coroutine never being awaited. (#66, PR by John Litborn)
 
 **1.1.2**

--- a/src/exceptiongroup/_catch.py
+++ b/src/exceptiongroup/_catch.py
@@ -58,7 +58,7 @@ class _Catcher:
                         raise TypeError(
                             f"Error trying to handle {matched!r} with {handler!r}. "
                             "Exception handler must be a sync function."
-                        ) from excgroup
+                        ) from exc
 
             if not excgroup:
                 break

--- a/src/exceptiongroup/_catch.py
+++ b/src/exceptiongroup/_catch.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import sys
 from collections.abc import Callable, Iterable, Mapping
 from contextlib import AbstractContextManager
@@ -49,9 +50,15 @@ class _Catcher:
             matched, excgroup = excgroup.split(exc_types)
             if matched:
                 try:
-                    handler(matched)
+                    result = handler(matched)
                 except BaseException as new_exc:
                     new_exceptions.append(new_exc)
+                else:
+                    if inspect.iscoroutine(result):
+                        raise TypeError(
+                            f"Error trying to handle {matched!r} with {handler!r}. "
+                            "Exception handler must be a sync function."
+                        )
 
             if not excgroup:
                 break

--- a/src/exceptiongroup/_catch.py
+++ b/src/exceptiongroup/_catch.py
@@ -58,7 +58,7 @@ class _Catcher:
                         raise TypeError(
                             f"Error trying to handle {matched!r} with {handler!r}. "
                             "Exception handler must be a sync function."
-                        )
+                        ) from excgroup
 
             if not excgroup:
                 break

--- a/tests/test_catch.py
+++ b/tests/test_catch.py
@@ -164,18 +164,15 @@ def test_catch_subclass():
     assert isinstance(exceptions[0], KeyError)
 
 
-def test_async_handler():
-    import asyncio
-
-    from exceptiongroup import ExceptionGroup, catch
-
+def test_async_handler(request):
     async def handler(eg):
-        # Log some stuff, then re-raise
-        raise eg
+        pass
 
-    async def main():
-        with catch({TypeError: handler}):
-            raise ExceptionGroup("message", TypeError("uh-oh"))
+    def delegate(eg):
+        coro = handler(eg)
+        request.addfinalizer(coro.close)
+        return coro
 
     with pytest.raises(TypeError, match="Exception handler must be a sync function."):
-        asyncio.run(main())
+        with catch({TypeError: delegate}):
+            raise ExceptionGroup("message", TypeError("uh-oh"))

--- a/tests/test_catch.py
+++ b/tests/test_catch.py
@@ -177,5 +177,5 @@ def test_async_handler():
         with catch({TypeError: handler}):
             raise ExceptionGroup("message", TypeError("uh-oh"))
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="Exception handler must be a sync function."):
         asyncio.run(main())

--- a/tests/test_catch.py
+++ b/tests/test_catch.py
@@ -162,3 +162,20 @@ def test_catch_subclass():
     assert isinstance(lookup_errors[0], ExceptionGroup)
     exceptions = lookup_errors[0].exceptions
     assert isinstance(exceptions[0], KeyError)
+
+
+def test_async_handler():
+    import asyncio
+
+    from exceptiongroup import ExceptionGroup, catch
+
+    async def handler(eg):
+        # Log some stuff, then re-raise
+        raise eg
+
+    async def main():
+        with catch({TypeError: handler}):
+            raise ExceptionGroup("message", TypeError("uh-oh"))
+
+    with pytest.raises(TypeError):
+        asyncio.run(main())


### PR DESCRIPTION
@Zac-HD 
Fixes #66 

I'm not entirely sure about the error message - which ones of `exc`, `excgroup`, `matched` and/or `exc_types` should be printed, and should we print the `str`, `repr`, or `__name__`.

Currently it looks like:
```
E   TypeError: Error trying to handle ExceptionGroup('', [TypeError('second argument (exceptions) must be a sequence')]) with <function test_async_handler.<locals>.handler at 0x7f319f598b80>. Exception handler must be a sync function
```

which certainly isn't the prettiest.