### PR TITLE
monkeypatch apport excepthook

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Install dependencies
       run: pip install -e .[test] coverage
     - name: Test with pytest
-      run: coverage run -m pytest -k apport
+      run: coverage run -m pytest -k apport -s
     - name: Upload Coverage
       uses: coverallsapp/github-action@v2
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,34 @@ jobs:
       with:
         parallel: true
 
+  test-apport:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", pypy-3.10]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: awalsh128/cache-apt-pkgs-action@latest
+      with:
+        packages: python3-apport
+        version: 1.0
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
+        cache: pip
+        cache-dependency-path: pyproject.toml
+    - name: Install dependencies
+      run: pip install -e .[test] coverage
+    - name: Test with pytest
+      run: coverage run -m pytest -- -k apport
+    - name: Upload Coverage
+      uses: coverallsapp/github-action@v2
+      with:
+        parallel: true
+
   coveralls:
     name: Finish Coveralls
     needs: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Install dependencies
       run: pip install -e .[test] coverage
     - name: Test with pytest
-      run: coverage run -m pytest -- -k apport
+      run: coverage run -m pytest -k apport
     - name: Upload Coverage
       uses: coverallsapp/github-action@v2
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,34 +47,6 @@ jobs:
       with:
         parallel: true
 
-  test-apport:
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", pypy-3.10]
-    runs-on: ubuntu-latest
-    steps:
-    - uses: awalsh128/cache-apt-pkgs-action@latest
-      with:
-        packages: python3-apport
-        version: 1.0
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-        allow-prereleases: true
-        cache: pip
-        cache-dependency-path: pyproject.toml
-    - name: Install dependencies
-      run: pip install -e .[test] coverage
-    - name: Test with pytest
-      run: coverage run -m pytest -k apport -s
-    - name: Upload Coverage
-      uses: coverallsapp/github-action@v2
-      with:
-        parallel: true
-
   coveralls:
     name: Finish Coveralls
     needs: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Install dependencies
       run: pip install -e .[test] coverage
     - name: Test with pytest
-      run: coverage run -m pytest
+      run: coverage run -m pytest -s
     - name: Upload Coverage
       uses: coverallsapp/github-action@v2
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Install dependencies
       run: pip install -e .[test] coverage
     - name: Test with pytest
-      run: coverage run -m pytest -s
+      run: coverage run -m pytest
     - name: Upload Coverage
       uses: coverallsapp/github-action@v2
       with:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
+**Future**
+- Added special monkeypatching if `Apport <https://github.com/canonical/apport>`_ has overridden ``sys.excepthook`` so it will format exception groups correctly.
+
 **1.1.3**
 
 - ``catch()`` now raises a ``TypeError`` if passed an async exception handler instead of

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,8 +3,11 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
-**Future**
-- Added special monkeypatching if `Apport <https://github.com/canonical/apport>`_ has overridden ``sys.excepthook`` so it will format exception groups correctly.
+**UNRELEASED**
+
+- Added special monkeypatching if `Apport <https://github.com/canonical/apport>`_ has
+  overridden ``sys.excepthook`` so it will format exception groups correctly
+  (PR by John Litborn)
 
 **1.1.3**
 

--- a/src/exceptiongroup/_formatting.py
+++ b/src/exceptiongroup/_formatting.py
@@ -359,7 +359,7 @@ if sys.excepthook is sys.__excepthook__:
     )
     sys.excepthook = exceptiongroup_excepthook
 
-# Ubuntu's system Python has a sitecustomize.py file that import
+# Ubuntu's system Python has a sitecustomize.py file that imports
 # apport_python_hook and replaces sys.excepthook.
 #
 # The custom hook captures the error for crash reporting, and then calls
@@ -376,8 +376,7 @@ if getattr(sys.excepthook, "__name__", None) in (
     # on ubuntu 22.10 the hook was renamed to partial_apport_excepthook
     "partial_apport_excepthook",
 ):
-    # TODO: Need to figure out what these do, and write test for them.
-    # TODO: do they need to be monkeypatched into apport_python_hook.traceback?
+    # patch traceback like above
     traceback.TracebackException.__init__ = (  # type: ignore[assignment]
         PatchedTracebackException.__init__
     )
@@ -388,17 +387,17 @@ if getattr(sys.excepthook, "__name__", None) in (
         PatchedTracebackException.format_exception_only
     )
 
-    # from types import ModuleType
+    from types import ModuleType
 
-    # import apport_python_hook
+    import apport_python_hook
 
-    # assert sys.excepthook is apport_python_hook.apport_excepthook
+    assert sys.excepthook is apport_python_hook.apport_excepthook
 
-    # # monkeypatch the sys module that apport has imported
-    # fake_sys = ModuleType("trio_fake_sys")
-    # fake_sys.__dict__.update(sys.__dict__)
-    # fake_sys.__excepthook__ = exceptiongroup_excepthook
-    # apport_python_hook.sys = fake_sys
+    # monkeypatch the sys module that apport has imported
+    fake_sys = ModuleType("trio_fake_sys")
+    fake_sys.__dict__.update(sys.__dict__)
+    fake_sys.__excepthook__ = exceptiongroup_excepthook
+    apport_python_hook.sys = fake_sys
 
 
 @singledispatch

--- a/src/exceptiongroup/_formatting.py
+++ b/src/exceptiongroup/_formatting.py
@@ -359,6 +359,47 @@ if sys.excepthook is sys.__excepthook__:
     )
     sys.excepthook = exceptiongroup_excepthook
 
+# Ubuntu's system Python has a sitecustomize.py file that import
+# apport_python_hook and replaces sys.excepthook.
+#
+# The custom hook captures the error for crash reporting, and then calls
+# sys.__excepthook__ to actually print the error.
+#
+# We don't mind it capturing the error for crash reporting, but we want to
+# take over printing the error. So we monkeypatch the apport_python_hook
+# module so that instead of calling sys.__excepthook__, it calls our custom
+# hook.
+#
+# More details: https://github.com/python-trio/trio/issues/1065
+if getattr(sys.excepthook, "__name__", None) in (
+    "apport_excepthook",
+    # on ubuntu 22.10 the hook was renamed to partial_apport_excepthook
+    "partial_apport_excepthook",
+):
+    # TODO: Need to figure out what these do, and write test for them.
+    # TODO: do they need to be monkeypatched into apport_python_hook.traceback?
+    traceback.TracebackException.__init__ = (  # type: ignore[assignment]
+        PatchedTracebackException.__init__
+    )
+    traceback.TracebackException.format = (  # type: ignore[assignment]
+        PatchedTracebackException.format
+    )
+    traceback.TracebackException.format_exception_only = (  # type: ignore[assignment]
+        PatchedTracebackException.format_exception_only
+    )
+
+    from types import ModuleType
+
+    import apport_python_hook
+
+    assert sys.excepthook is apport_python_hook.apport_excepthook
+
+    # monkeypatch the sys module that apport has imported
+    fake_sys = ModuleType("trio_fake_sys")
+    fake_sys.__dict__.update(sys.__dict__)
+    fake_sys.__excepthook__ = exceptiongroup_excepthook
+    apport_python_hook.sys = fake_sys
+
 
 @singledispatch
 def format_exception_only(__exc: BaseException) -> List[str]:
@@ -561,44 +602,3 @@ def _levenshtein_distance(a, b, max_cost):
             # Everything in this row is too big, so bail early.
             return max_cost + 1
     return result
-
-
-# Ubuntu's system Python has a sitecustomize.py file that import
-# apport_python_hook and replaces sys.excepthook.
-#
-# The custom hook captures the error for crash reporting, and then calls
-# sys.__excepthook__ to actually print the error.
-#
-# We don't mind it capturing the error for crash reporting, but we want to
-# take over printing the error. So we monkeypatch the apport_python_hook
-# module so that instead of calling sys.__excepthook__, it calls our custom
-# hook.
-#
-# More details: https://github.com/python-trio/trio/issues/1065
-if getattr(sys.excepthook, "__name__", None) in (
-    "apport_excepthook",
-    "partial_apport_excepthook",
-):
-    from types import ModuleType
-
-    import apport_python_hook
-
-    assert sys.excepthook is apport_python_hook.apport_excepthook
-
-    # def exceptiongroup_excepthook(
-    #    etype: type[BaseException], value: BaseException, tb: TracebackType | None
-    # ) -> None:
-    #    sys.stderr.write("".join(traceback.format_exception(etype, value, tb)))
-    def replacement_excepthook(
-        etype: type[BaseException], value: BaseException, tb: TracebackType | None
-    ) -> None:
-        # This does work, it's an overloaded function
-        sys.stderr.write("".join(format_exception(etype, value, tb)))  # type: ignore[arg-type]
-
-    # monkeypatch the sys module that apport has imported
-    fake_sys = ModuleType("trio_fake_sys")
-    fake_sys.__dict__.update(sys.__dict__)
-    # Fake does have __excepthook__ after __dict__ update, but type checkers don't
-    # recognize this
-    fake_sys.__excepthook__ = replacement_excepthook  # type: ignore[attr-defined]
-    apport_python_hook.sys = fake_sys

--- a/src/exceptiongroup/_formatting.py
+++ b/src/exceptiongroup/_formatting.py
@@ -394,7 +394,7 @@ if getattr(sys.excepthook, "__name__", None) in (
     assert sys.excepthook is apport_python_hook.apport_excepthook
 
     # monkeypatch the sys module that apport has imported
-    fake_sys = ModuleType("trio_fake_sys")
+    fake_sys = ModuleType("exceptiongroup_fake_sys")
     fake_sys.__dict__.update(sys.__dict__)
     fake_sys.__excepthook__ = exceptiongroup_excepthook
     apport_python_hook.sys = fake_sys

--- a/src/exceptiongroup/_formatting.py
+++ b/src/exceptiongroup/_formatting.py
@@ -378,27 +378,27 @@ if getattr(sys.excepthook, "__name__", None) in (
 ):
     # TODO: Need to figure out what these do, and write test for them.
     # TODO: do they need to be monkeypatched into apport_python_hook.traceback?
-    # traceback.TracebackException.__init__ = (  # type: ignore[assignment]
-    #    PatchedTracebackException.__init__
-    # )
-    # traceback.TracebackException.format = (  # type: ignore[assignment]
-    #    PatchedTracebackException.format
-    # )
-    # traceback.TracebackException.format_exception_only = (  # type: ignore[assignment]
-    #    PatchedTracebackException.format_exception_only
-    # )
+    traceback.TracebackException.__init__ = (  # type: ignore[assignment]
+        PatchedTracebackException.__init__
+    )
+    traceback.TracebackException.format = (  # type: ignore[assignment]
+        PatchedTracebackException.format
+    )
+    traceback.TracebackException.format_exception_only = (  # type: ignore[assignment]
+        PatchedTracebackException.format_exception_only
+    )
 
-    from types import ModuleType
+    # from types import ModuleType
 
-    import apport_python_hook
+    # import apport_python_hook
 
-    assert sys.excepthook is apport_python_hook.apport_excepthook
+    # assert sys.excepthook is apport_python_hook.apport_excepthook
 
-    # monkeypatch the sys module that apport has imported
-    fake_sys = ModuleType("trio_fake_sys")
-    fake_sys.__dict__.update(sys.__dict__)
-    fake_sys.__excepthook__ = exceptiongroup_excepthook
-    apport_python_hook.sys = fake_sys
+    # # monkeypatch the sys module that apport has imported
+    # fake_sys = ModuleType("trio_fake_sys")
+    # fake_sys.__dict__.update(sys.__dict__)
+    # fake_sys.__excepthook__ = exceptiongroup_excepthook
+    # apport_python_hook.sys = fake_sys
 
 
 @singledispatch

--- a/src/exceptiongroup/_formatting.py
+++ b/src/exceptiongroup/_formatting.py
@@ -378,15 +378,15 @@ if getattr(sys.excepthook, "__name__", None) in (
 ):
     # TODO: Need to figure out what these do, and write test for them.
     # TODO: do they need to be monkeypatched into apport_python_hook.traceback?
-    traceback.TracebackException.__init__ = (  # type: ignore[assignment]
-        PatchedTracebackException.__init__
-    )
-    traceback.TracebackException.format = (  # type: ignore[assignment]
-        PatchedTracebackException.format
-    )
-    traceback.TracebackException.format_exception_only = (  # type: ignore[assignment]
-        PatchedTracebackException.format_exception_only
-    )
+    # traceback.TracebackException.__init__ = (  # type: ignore[assignment]
+    #    PatchedTracebackException.__init__
+    # )
+    # traceback.TracebackException.format = (  # type: ignore[assignment]
+    #    PatchedTracebackException.format
+    # )
+    # traceback.TracebackException.format_exception_only = (  # type: ignore[assignment]
+    #    PatchedTracebackException.format_exception_only
+    # )
 
     from types import ModuleType
 

--- a/tests/apport_excepthook.py
+++ b/tests/apport_excepthook.py
@@ -1,0 +1,13 @@
+# The apport_python_hook package is only installed as part of Ubuntu's system
+# python, and not available in venvs. So before we can import it we have to
+# make sure it's on sys.path.
+import sys
+
+sys.path.append("/usr/lib/python3/dist-packages")
+import apport_python_hook  # noqa: E402 # unsorted import
+
+apport_python_hook.install()
+
+from exceptiongroup import ExceptionGroup  # noqa: E402 # unsorted import
+
+raise ExceptionGroup("group_error", [KeyError("key_error"), ValueError("value_error")])

--- a/tests/apport_excepthook.py
+++ b/tests/apport_excepthook.py
@@ -10,4 +10,4 @@ apport_python_hook.install()
 
 from exceptiongroup import ExceptionGroup  # noqa: E402 # unsorted import
 
-raise ExceptionGroup("group_error", [KeyError("key_error"), ValueError("value_error")])
+raise ExceptionGroup("msg1", [KeyError("msg2"), ValueError("msg3")])

--- a/tests/test_apport_monkeypatching.py
+++ b/tests/test_apport_monkeypatching.py
@@ -57,10 +57,12 @@ def test_apport_excepthook_monkeypatch_interaction():
     # No warning
     assert "custom sys.excepthook" not in stdout
 
+    print(stdout)
     # Proper traceback
     assert_match_in_seq(
         [
             "ExceptionGroup",
+            "sub-exception",
             "group_error",
             "KeyError",
             "key_error",

--- a/tests/test_apport_monkeypatching.py
+++ b/tests/test_apport_monkeypatching.py
@@ -50,7 +50,7 @@ def test_apport_excepthook_monkeypatch_interaction():
 + Exception Group Traceback (most recent call last):
   |   File "{file}", line 13, in <module>
   |     raise ExceptionGroup("msg1", [KeyError("msg2"), ValueError("msg3")])
-  | exceptiongroup.ExceptionGroup: group_error (2 sub-exceptions)
+  | exceptiongroup.ExceptionGroup: msg1 (2 sub-exceptions)
   +-+---------------- 1 ----------------
     | KeyError: 'msg2'
     +---------------- 2 ----------------

--- a/tests/test_apport_monkeypatching.py
+++ b/tests/test_apport_monkeypatching.py
@@ -57,7 +57,6 @@ def test_apport_excepthook_monkeypatch_interaction():
     # No warning
     assert "custom sys.excepthook" not in stdout
 
-    print(stdout)
     # Proper traceback
     assert_match_in_seq(
         [

--- a/tests/test_apport_monkeypatching.py
+++ b/tests/test_apport_monkeypatching.py
@@ -1,0 +1,64 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import exceptiongroup
+
+
+def run_script(name: str) -> subprocess.CompletedProcess[bytes]:
+    exceptiongroup_path = Path(exceptiongroup.__file__).parent.parent
+    script_path = Path(__file__).parent / name
+
+    env = dict(os.environ)
+    print("parent PYTHONPATH:", env.get("PYTHONPATH"))
+    if "PYTHONPATH" in env:  # pragma: no cover
+        pp = env["PYTHONPATH"].split(os.pathsep)
+    else:
+        pp = []
+    pp.insert(0, str(exceptiongroup_path))
+    pp.insert(0, str(script_path.parent))
+    env["PYTHONPATH"] = os.pathsep.join(pp)
+    print("subprocess PYTHONPATH:", env.get("PYTHONPATH"))
+
+    cmd = [sys.executable, "-u", str(script_path)]
+    print("running:", cmd)
+    completed = subprocess.run(
+        cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+    )
+    print("process output:")
+    print(completed.stdout.decode("utf-8"))
+    return completed
+
+
+def assert_match_in_seq(pattern_list, string):
+    import re
+
+    offset = 0
+    print("looking for pattern matches...")
+    for pattern in pattern_list:
+        print("checking pattern:", pattern)
+        reobj = re.compile(pattern)
+        match = reobj.search(string, offset)
+        assert match is not None
+        offset = match.end()
+
+
+@pytest.mark.skipif(
+    not Path("/usr/lib/python3/dist-packages/apport_python_hook.py").exists(),
+    reason="need Ubuntu with python3-apport installed",
+)
+def test_apport_excepthook_monkeypatch_interaction():
+    completed = run_script("apport_excepthook.py")
+    stdout = completed.stdout.decode("utf-8")
+
+    # No warning
+    assert "custom sys.excepthook" not in stdout
+
+    # Proper traceback
+    assert_match_in_seq(
+        ["--- 1 ---", "KeyError", "--- 2 ---", "ValueError"],
+        stdout,
+    )

--- a/tests/test_apport_monkeypatching.py
+++ b/tests/test_apport_monkeypatching.py
@@ -53,6 +53,7 @@ def assert_match_in_seq(pattern_list, string):
 def test_apport_excepthook_monkeypatch_interaction():
     completed = run_script("apport_excepthook.py")
     stdout = completed.stdout.decode("utf-8")
+    print(stdout)
 
     # No warning
     assert "custom sys.excepthook" not in stdout
@@ -72,4 +73,3 @@ def test_apport_excepthook_monkeypatch_interaction():
         ],
         stdout,
     )
-    print(stdout)

--- a/tests/test_apport_monkeypatching.py
+++ b/tests/test_apport_monkeypatching.py
@@ -8,7 +8,7 @@ import pytest
 import exceptiongroup
 
 
-def run_script(name: str) -> subprocess.CompletedProcess[bytes]:
+def run_script(name: str) -> "subprocess.CompletedProcess[bytes]":
     exceptiongroup_path = Path(exceptiongroup.__file__).parent.parent
     script_path = Path(__file__).parent / name
 

--- a/tests/test_apport_monkeypatching.py
+++ b/tests/test_apport_monkeypatching.py
@@ -59,6 +59,13 @@ def test_apport_excepthook_monkeypatch_interaction():
 
     # Proper traceback
     assert_match_in_seq(
-        ["--- 1 ---", "KeyError", "--- 2 ---", "ValueError"],
+        [
+            "ExceptionGroup",
+            "group_error",
+            "KeyError",
+            "key_error",
+            "ValueError",
+            "value_error",
+        ],
         stdout,
     )

--- a/tests/test_apport_monkeypatching.py
+++ b/tests/test_apport_monkeypatching.py
@@ -60,6 +60,7 @@ def test_apport_excepthook_monkeypatch_interaction():
     # Proper traceback
     assert_match_in_seq(
         [
+            "Exception Group Traceback",
             "ExceptionGroup",
             "group_error",
             "----- 1 -----",
@@ -71,3 +72,4 @@ def test_apport_excepthook_monkeypatch_interaction():
         ],
         stdout,
     )
+    print(stdout)

--- a/tests/test_apport_monkeypatching.py
+++ b/tests/test_apport_monkeypatching.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import subprocess
 import sys
@@ -8,7 +10,7 @@ import pytest
 import exceptiongroup
 
 
-def run_script(name: str) -> "subprocess.CompletedProcess[bytes]":
+def run_script(name: str) -> subprocess.CompletedProcess[bytes]:
     exceptiongroup_path = Path(exceptiongroup.__file__).parent.parent
     script_path = Path(__file__).parent / name
 
@@ -18,6 +20,7 @@ def run_script(name: str) -> "subprocess.CompletedProcess[bytes]":
         pp = env["PYTHONPATH"].split(os.pathsep)
     else:
         pp = []
+
     pp.insert(0, str(exceptiongroup_path))
     pp.insert(0, str(script_path.parent))
     env["PYTHONPATH"] = os.pathsep.join(pp)

--- a/tests/test_apport_monkeypatching.py
+++ b/tests/test_apport_monkeypatching.py
@@ -47,7 +47,7 @@ def test_apport_excepthook_monkeypatch_interaction():
     file = Path(__file__).parent / "apport_excepthook.py"
     assert stdout == (
         f"""\
-+ Exception Group Traceback (most recent call last):
+  + Exception Group Traceback (most recent call last):
   |   File "{file}", line 13, in <module>
   |     raise ExceptionGroup("msg1", [KeyError("msg2"), ValueError("msg3")])
   | exceptiongroup.ExceptionGroup: msg1 (2 sub-exceptions)

--- a/tests/test_apport_monkeypatching.py
+++ b/tests/test_apport_monkeypatching.py
@@ -62,10 +62,11 @@ def test_apport_excepthook_monkeypatch_interaction():
     assert_match_in_seq(
         [
             "ExceptionGroup",
-            "sub-exception",
             "group_error",
+            "----- 1 -----",
             "KeyError",
             "key_error",
+            "----- 2 -----",
             "ValueError",
             "value_error",
         ],


### PR DESCRIPTION
This mostly just copies over code from trio, that had logic for making sure `MultiError`s got printed despite `apport` messing with `sys.__excepthook__`. I'm planning to clean up the test code a bit more, and could move it into `test_formatting` if you want.
I added the `-s` to pytest in CI to help debugging, but I'll remove it again unless you like verbose tests.

Don't love the `traceback.TraceBackException` patch code duplication, should probably move that into a separate helper function or something. It could maybe also live outside the if statements (?).

I left the messy commit history I racked up in https://github.com/jakkdl/exceptiongroup/pull/1 in case you want to see test runs where it failed without the patch.