### PR TITLE
expand CI pyright to use full python version matrix and fix type errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,13 +7,17 @@ on:
 
 jobs:
   pyright:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.x
+        python-version: ${{ matrix.python-version }}
     - uses: actions/cache@v3
       with:
         path: ~/.cache/pip
@@ -21,7 +25,7 @@ jobs:
     - name: Install dependencies
       run: pip install -e . pyright
     - name: Run pyright
-      run: pyright --verifytypes exceptiongroup
+      run: pyright --verifytypes exceptiongroup --verbose
 
   test:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,8 @@ exclude_lines = [
 legacy_tox_ini = """
 [tox]
 envlist = py37, py38, py39, py310, py311, py312, pypy3
+labels =
+    pyright = py{310,311,312}-pyright
 skip_missing_interpreters = true
 minversion = 4.0
 
@@ -87,7 +89,7 @@ extras = test
 commands = python -m pytest {posargs}
 usedevelop = true
 
-[testenv:pyright]
+[testenv:{py37-,py38-,py39-,py310-,py311-,py312-,}pyright]
 deps = pyright
 commands = pyright --verifytypes exceptiongroup
 usedevelop = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,8 +70,7 @@ source = ["exceptiongroup"]
 relative_files = true
 
 [tool.coverage.report]
-exclude_lines = [
-    "pragma: no cover",
+exclude_also = [
     "if TYPE_CHECKING:",
     "@overload",
 ]
@@ -86,9 +85,8 @@ skip_missing_interpreters = true
 minversion = 4.0
 
 [testenv]
-deps = coverage
 extras = test
-commands = coverage run -p -m pytest {posargs}
+commands = python -m pytest {posargs}
 usedevelop = true
 
 [testenv:{py37-,py38-,py39-,py310-,py311-,py312-,}pyright]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,8 @@ relative_files = true
 [tool.coverage.report]
 exclude_lines = [
     "pragma: no cover",
-    "if TYPE_CHECKING:"
+    "if TYPE_CHECKING:",
+    "@overload",
 ]
 
 [tool.tox]
@@ -85,8 +86,9 @@ skip_missing_interpreters = true
 minversion = 4.0
 
 [testenv]
+deps = coverage
 extras = test
-commands = python -m pytest {posargs}
+commands = coverage run -p -m pytest {posargs}
 usedevelop = true
 
 [testenv:{py37-,py38-,py39-,py310-,py311-,py312-,}pyright]

--- a/src/exceptiongroup/_exceptions.py
+++ b/src/exceptiongroup/_exceptions.py
@@ -11,7 +11,7 @@ _ExceptionT_co = TypeVar("_ExceptionT_co", bound=Exception, covariant=True)
 _ExceptionT = TypeVar("_ExceptionT", bound=Exception)
 # using typing.Self would require a typing_extensions dependency on py<3.11
 _ExceptionGroupSelf = TypeVar("_ExceptionGroupSelf", bound="ExceptionGroup")
-_BaseExceptionGroupSelf = TypeVar("_BaseExceptionGroupSelf", bound="ExceptionGroup")
+_BaseExceptionGroupSelf = TypeVar("_BaseExceptionGroupSelf", bound="BaseExceptionGroup")
 
 
 def check_direct_subclass(

--- a/src/exceptiongroup/_exceptions.py
+++ b/src/exceptiongroup/_exceptions.py
@@ -5,13 +5,13 @@ from functools import partial
 from inspect import getmro, isclass
 from typing import TYPE_CHECKING, Generic, Type, TypeVar, cast, overload
 
-if TYPE_CHECKING:
-    from typing import Self
-
 _BaseExceptionT_co = TypeVar("_BaseExceptionT_co", bound=BaseException, covariant=True)
 _BaseExceptionT = TypeVar("_BaseExceptionT", bound=BaseException)
 _ExceptionT_co = TypeVar("_ExceptionT_co", bound=Exception, covariant=True)
 _ExceptionT = TypeVar("_ExceptionT", bound=Exception)
+# using typing.Self would require a typing_extensions dependency on py<3.11
+_ExceptionGroupSelf = TypeVar("_ExceptionGroupSelf", bound="ExceptionGroup")
+_BaseExceptionGroupSelf = TypeVar("_BaseExceptionGroupSelf", bound="ExceptionGroup")
 
 
 def check_direct_subclass(
@@ -46,8 +46,10 @@ class BaseExceptionGroup(BaseException, Generic[_BaseExceptionT_co]):
     """A combination of multiple unrelated exceptions."""
 
     def __new__(
-        cls, __message: str, __exceptions: Sequence[_BaseExceptionT_co]
-    ) -> Self:
+        cls: _BaseExceptionGroupSelf,
+        __message: str,
+        __exceptions: Sequence[_BaseExceptionT_co],
+    ) -> _BaseExceptionGroupSelf:
         if not isinstance(__message, str):
             raise TypeError(f"argument 1 must be str, not {type(__message)}")
         if not isinstance(__exceptions, Sequence):
@@ -119,7 +121,8 @@ class BaseExceptionGroup(BaseException, Generic[_BaseExceptionT_co]):
 
     @overload
     def subgroup(
-        self, __condition: Callable[[_BaseExceptionT_co | Self], bool]
+        self,
+        __condition: Callable[[_BaseExceptionT_co | _BaseExceptionGroupSelf], bool],
     ) -> BaseExceptionGroup[_BaseExceptionT_co] | None:
         ...
 
@@ -127,7 +130,7 @@ class BaseExceptionGroup(BaseException, Generic[_BaseExceptionT_co]):
         self,
         __condition: type[_BaseExceptionT]
         | tuple[type[_BaseExceptionT], ...]
-        | Callable[[_BaseExceptionT_co | Self], bool],
+        | Callable[[_BaseExceptionT_co | _BaseExceptionGroupSelf], bool],
     ) -> BaseExceptionGroup[_BaseExceptionT] | None:
         condition = get_condition_filter(__condition)
         modified = False
@@ -179,7 +182,8 @@ class BaseExceptionGroup(BaseException, Generic[_BaseExceptionT_co]):
 
     @overload
     def split(
-        self, __condition: Callable[[_BaseExceptionT_co | Self], bool]
+        self,
+        __condition: Callable[[_BaseExceptionT_co | _BaseExceptionGroupSelf], bool],
     ) -> tuple[
         BaseExceptionGroup[_BaseExceptionT_co] | None,
         BaseExceptionGroup[_BaseExceptionT_co] | None,
@@ -224,14 +228,14 @@ class BaseExceptionGroup(BaseException, Generic[_BaseExceptionT_co]):
             else:
                 nonmatching_exceptions.append(exc)
 
-        matching_group: Self | None = None
+        matching_group: _BaseExceptionGroupSelf | None = None
         if matching_exceptions:
             matching_group = self.derive(matching_exceptions)
             matching_group.__cause__ = self.__cause__
             matching_group.__context__ = self.__context__
             matching_group.__traceback__ = self.__traceback__
 
-        nonmatching_group: Self | None = None
+        nonmatching_group: _BaseExceptionGroupSelf | None = None
         if nonmatching_exceptions:
             nonmatching_group = self.derive(nonmatching_exceptions)
             nonmatching_group.__cause__ = self.__cause__
@@ -269,7 +273,9 @@ class BaseExceptionGroup(BaseException, Generic[_BaseExceptionT_co]):
 
 
 class ExceptionGroup(BaseExceptionGroup[_ExceptionT_co], Exception):
-    def __new__(cls, __message: str, __exceptions: Sequence[_ExceptionT_co]) -> Self:
+    def __new__(
+        cls, __message: str, __exceptions: Sequence[_ExceptionT_co]
+    ) -> _ExceptionGroupSelf:
         return super().__new__(cls, __message, __exceptions)
 
     if TYPE_CHECKING:
@@ -288,7 +294,7 @@ class ExceptionGroup(BaseExceptionGroup[_ExceptionT_co], Exception):
 
         @overload
         def subgroup(
-            self, __condition: Callable[[_ExceptionT_co | Self], bool]
+            self, __condition: Callable[[_ExceptionT_co | _ExceptionGroupSelf], bool]
         ) -> ExceptionGroup[_ExceptionT_co] | None:
             ...
 
@@ -310,14 +316,14 @@ class ExceptionGroup(BaseExceptionGroup[_ExceptionT_co], Exception):
 
         @overload
         def split(
-            self, __condition: Callable[[_ExceptionT_co | Self], bool]
+            self, __condition: Callable[[_ExceptionT_co | _ExceptionGroupSelf], bool]
         ) -> tuple[
             ExceptionGroup[_ExceptionT_co] | None, ExceptionGroup[_ExceptionT_co] | None
         ]:
             ...
 
         def split(
-            self: Self,
+            self: _ExceptionGroupSelf,
             __condition: type[_ExceptionT]
             | tuple[type[_ExceptionT], ...]
             | Callable[[_ExceptionT_co], bool],

--- a/src/exceptiongroup/_suppress.py
+++ b/src/exceptiongroup/_suppress.py
@@ -1,7 +1,7 @@
 import sys
 from contextlib import AbstractContextManager
 from types import TracebackType
-from typing import TYPE_CHECKING, Type
+from typing import TYPE_CHECKING, Optional, Type
 
 if sys.version_info < (3, 11):
     from ._exceptions import BaseExceptionGroup
@@ -23,7 +23,10 @@ class suppress(BaseClass):
         pass
 
     def __exit__(
-        self, exctype: Type[BaseException], excinst: BaseException, exctb: TracebackType
+        self,
+        exctype: Optional[Type[BaseException]],
+        excinst: Optional[BaseException],
+        exctb: Optional[TracebackType],
     ) -> bool:
         # Unlike isinstance and issubclass, CPython exception handling
         # currently only looks at the concrete type hierarchy (ignoring

--- a/src/exceptiongroup/_suppress.py
+++ b/src/exceptiongroup/_suppress.py
@@ -1,20 +1,24 @@
 import sys
 from contextlib import AbstractContextManager
+from types import TracebackType
+from typing import Type
 
 if sys.version_info < (3, 11):
     from ._exceptions import BaseExceptionGroup
 
 
-class suppress(AbstractContextManager):
+class suppress(AbstractContextManager[None]):
     """Backport of :class:`contextlib.suppress` from Python 3.12.1."""
 
-    def __init__(self, *exceptions):
+    def __init__(self, *exceptions: BaseException):
         self._exceptions = exceptions
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         pass
 
-    def __exit__(self, exctype, excinst, exctb):
+    def __exit__(
+        self, exctype: Type[BaseException], excinst: BaseException, exctb: TracebackType
+    ) -> bool:
         # Unlike isinstance and issubclass, CPython exception handling
         # currently only looks at the concrete type hierarchy (ignoring
         # the instance and subclass checking hooks). While Guido considers
@@ -25,7 +29,7 @@ class suppress(AbstractContextManager):
         #
         # See http://bugs.python.org/issue12029 for more details
         if exctype is None:
-            return
+            return False
 
         if issubclass(exctype, self._exceptions):
             return True

--- a/src/exceptiongroup/_suppress.py
+++ b/src/exceptiongroup/_suppress.py
@@ -1,13 +1,19 @@
 import sys
 from contextlib import AbstractContextManager
 from types import TracebackType
-from typing import Type
+from typing import TYPE_CHECKING, Type
 
 if sys.version_info < (3, 11):
     from ._exceptions import BaseExceptionGroup
 
+if TYPE_CHECKING:
+    # requires python 3.9
+    BaseClass = AbstractContextManager[None]
+else:
+    BaseClass = AbstractContextManager
 
-class suppress(AbstractContextManager[None]):
+
+class suppress(BaseClass):
     """Backport of :class:`contextlib.suppress` from Python 3.12.1."""
 
     def __init__(self, *exceptions: BaseException):


### PR DESCRIPTION
(oops, meant to create this in my fork at first - sorry for the messiness in the PR)

It's perhaps a bit overkill to run pyright on the full test matrix, but with one backport from 3.11 and one from 3.12 we at least need to run <3.11, 3.11 and 3.12

* Adds type hints to _suppress.py
* replaces usage of `Self` with `TypeVar`s. Fixes #100 
* exclude `@overload` from coverage