### PR TITLE
Include CHANGES.rst in the sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ test = [
 
 [tool.flit.sdist]
 include = [
+    "CHANGES.rst",
     "tests",
 ]
 exclude = [


### PR DESCRIPTION
It makes sense to include `CHANGES.rst` alongside `README.rst` in the sdist.