### PR TITLE
Fix system exit hang on Python 3.8

### DIFF
--- a/src/exceptiongroup/_catch.py
+++ b/src/exceptiongroup/_catch.py
@@ -36,6 +36,8 @@ class _Catcher:
             else:
                 if isinstance(exc, BaseExceptionGroup):
                     try:
+                        if isinstance(unhandled, SystemExit):
+                            sys.exit(unhandled.code)
                         raise unhandled from exc.__cause__
                     except BaseExceptionGroup:
                         # Change __context__ to __cause__ because Python 3.11 does this


### PR DESCRIPTION
I don't understand why, but it fixes a bug where an [Asphalt](https://github.com/asphalt-framework/asphalt/tree/5.0) application hangs while raising a `SystemExit` [here](https://github.com/asphalt-framework/asphalt/actions/runs/8364912636/job/22901437246).