### PR TITLE
fix type errors, add type tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,9 @@ jobs:
     - name: Run pyright verifytypes
       run: pyright --verifytypes exceptiongroup --verbose
     - name: Run pyright type test
-      run: pyright tests/type_test.py
+      run: pyright tests/check_types.py
     - name: Run mypy type test
-      run: mypy tests/type_test.py
+      run: mypy tests/check_types.py
 
   test:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         key: pip-pyright
     - name: Install dependencies
       run: pip install -e . pyright mypy
-    - name: Run pyright verifytypes
+    - name: Run pyright --verifytypes
       run: pyright --verifytypes exceptiongroup --verbose
     - name: Run pyright type test
       run: pyright tests/check_types.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  pyright:
+  typing:
     strategy:
       fail-fast: false
       matrix:
@@ -23,9 +23,13 @@ jobs:
         path: ~/.cache/pip
         key: pip-pyright
     - name: Install dependencies
-      run: pip install -e . pyright
-    - name: Run pyright
+      run: pip install -e . pyright mypy
+    - name: Run pyright verifytypes
       run: pyright --verifytypes exceptiongroup --verbose
+    - name: Run pyright type test
+      run: pyright tests/type_test.py
+    - name: Run mypy type test
+      run: mypy tests/type_test.py
 
   test:
     strategy:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,10 +3,12 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
-**UNRELEASED**
+**1.2.1**
 
 - Corrected the type annotation of the exception handler callback to accept a
   ``BaseExceptionGroup`` instead of ``BaseException``
+- Fix type errors on python < 3.10 (PR by John Litborn)
+- Fixed type annotation of ``suppress()``. (PR by John Litborn)
 
 **1.2.0**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,8 +8,8 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 - Updated the copying of ``__notes__`` to match CPython behavior (PR by CF Bolz-Tereick)
 - Corrected the type annotation of the exception handler callback to accept a
   ``BaseExceptionGroup`` instead of ``BaseException``
-- Fixed type errors on Python < 3.10 (PR by John Litborn)
-- Fixed type annotation of ``suppress()``. (PR by John Litborn)
+- Fixed type errors on Python < 3.10 and the type annotation of ``suppress()``
+  (PR by John Litborn)
 
 **1.2.0**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,12 +3,12 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
-**1.2.1**
+**UNRELEASED**
 
-- ``BaseExceptionGroup.derive`` no longer copies ``__notes__``, instead copying ``__notes__`` in the *callers* of ``derive``. This makes the behaviour follow CPython more closely. (#112; PR by CF Bolz-Tereick)
+- Updated the copying of ``__notes__`` to match CPython behavior (PR by CF Bolz-Tereick)
 - Corrected the type annotation of the exception handler callback to accept a
   ``BaseExceptionGroup`` instead of ``BaseException``
-- Fix type errors on python < 3.10 (PR by John Litborn)
+- Fixed type errors on Python < 3.10 (PR by John Litborn)
 - Fixed type annotation of ``suppress()``. (PR by John Litborn)
 
 **1.2.0**

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
 
 **1.2.1**
 
+- ``BaseExceptionGroup.derive`` no longer copies ``__notes__``, instead copying ``__notes__`` in the *callers* of ``derive``. This makes the behaviour follow CPython more closely. (#112; PR by CF Bolz-Tereick)
 - Corrected the type annotation of the exception handler callback to accept a
   ``BaseExceptionGroup`` instead of ``BaseException``
 - Fix type errors on python < 3.10 (PR by John Litborn)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ version_scheme = "post-release"
 local_scheme = "dirty-tag"
 write_to = "src/exceptiongroup/_version.py"
 
-[tool.ruff]
+[tool.ruff.lint]
 select = [
     "E", "F", "W",  # default flake-8
     "I",            # isort
@@ -55,11 +55,11 @@ select = [
     "UP",           # pyupgrade
 ]
 
-[tool.ruff.pyupgrade]
+[tool.ruff.lint.pyupgrade]
 # Preserve types, even if a file imports `from __future__ import annotations`.
 keep-runtime-typing = true
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["exceptiongroup"]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,14 @@ exclude_also = [
     "@overload",
 ]
 
+[tool.pyright]
+# for type tests, the code itself isn't type checked in CI
+reportUnnecessaryTypeIgnoreComment = true
+
+[tool.mypy]
+# for type tests, the code itself isn't type checked in CI
+warn_unused_ignores = true
+
 [tool.tox]
 legacy_tox_ini = """
 [tox]
@@ -91,7 +99,12 @@ commands = python -m pytest {posargs}
 usedevelop = true
 
 [testenv:{py37-,py38-,py39-,py310-,py311-,py312-,}pyright]
-deps = pyright
-commands = pyright --verifytypes exceptiongroup
+deps =
+    pyright
+    mypy
+commands =
+    pyright --verifytypes exceptiongroup
+    pyright tests/type_test.py
+    mypy tests/type_test.py
 usedevelop = true
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ legacy_tox_ini = """
 [tox]
 envlist = py37, py38, py39, py310, py311, py312, pypy3
 labels =
-    pyright = py{310,311,312}-pyright
+    typing = py{310,311,312}-typing
 skip_missing_interpreters = true
 minversion = 4.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,13 +98,13 @@ extras = test
 commands = python -m pytest {posargs}
 usedevelop = true
 
-[testenv:{py37-,py38-,py39-,py310-,py311-,py312-,}pyright]
+[testenv:{py37-,py38-,py39-,py310-,py311-,py312-,}typing]
 deps =
     pyright
     mypy
 commands =
     pyright --verifytypes exceptiongroup
-    pyright tests/type_test.py
-    mypy tests/type_test.py
+    pyright tests/check_types.py
+    mypy tests/check_types.py
 usedevelop = true
 """

--- a/src/exceptiongroup/_exceptions.py
+++ b/src/exceptiongroup/_exceptions.py
@@ -57,7 +57,7 @@ class BaseExceptionGroup(BaseException, Generic[_BaseExceptionT_co]):
     """A combination of multiple unrelated exceptions."""
 
     def __new__(
-        cls: _BaseExceptionGroupSelf,
+        cls: type[_BaseExceptionGroupSelf],
         __message: str,
         __exceptions: Sequence[_BaseExceptionT_co],
     ) -> _BaseExceptionGroupSelf:
@@ -265,7 +265,7 @@ class BaseExceptionGroup(BaseException, Generic[_BaseExceptionT_co]):
 
 class ExceptionGroup(BaseExceptionGroup[_ExceptionT_co], Exception):
     def __new__(
-        cls, __message: str, __exceptions: Sequence[_ExceptionT_co]
+            cls: type[_ExceptionGroupSelf], __message: str, __exceptions: Sequence[_ExceptionT_co]
     ) -> _ExceptionGroupSelf:
         return super().__new__(cls, __message, __exceptions)
 

--- a/src/exceptiongroup/_exceptions.py
+++ b/src/exceptiongroup/_exceptions.py
@@ -265,7 +265,9 @@ class BaseExceptionGroup(BaseException, Generic[_BaseExceptionT_co]):
 
 class ExceptionGroup(BaseExceptionGroup[_ExceptionT_co], Exception):
     def __new__(
-            cls: type[_ExceptionGroupSelf], __message: str, __exceptions: Sequence[_ExceptionT_co]
+        cls: type[_ExceptionGroupSelf],
+        __message: str,
+        __exceptions: Sequence[_ExceptionT_co],
     ) -> _ExceptionGroupSelf:
         return super().__new__(cls, __message, __exceptions)
 

--- a/src/exceptiongroup/_suppress.py
+++ b/src/exceptiongroup/_suppress.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from contextlib import AbstractContextManager
 from types import TracebackType

--- a/src/exceptiongroup/_suppress.py
+++ b/src/exceptiongroup/_suppress.py
@@ -1,7 +1,7 @@
 import sys
 from contextlib import AbstractContextManager
 from types import TracebackType
-from typing import TYPE_CHECKING, Optional, Type
+from typing import TYPE_CHECKING, Optional, Type, cast
 
 if sys.version_info < (3, 11):
     from ._exceptions import BaseExceptionGroup
@@ -16,7 +16,7 @@ else:
 class suppress(BaseClass):
     """Backport of :class:`contextlib.suppress` from Python 3.12.1."""
 
-    def __init__(self, *exceptions: BaseException):
+    def __init__(self, *exceptions: type[BaseException]):
         self._exceptions = exceptions
 
     def __enter__(self) -> None:
@@ -44,7 +44,7 @@ class suppress(BaseClass):
             return True
 
         if issubclass(exctype, BaseExceptionGroup):
-            match, rest = excinst.split(self._exceptions)
+            match, rest = cast(BaseExceptionGroup, excinst).split(self._exceptions)
             if rest is None:
                 return True
 

--- a/tests/check_types.py
+++ b/tests/check_types.py
@@ -11,7 +11,7 @@ c = ExceptionGroup("", (ValueError(),))
 assert_type(c, ExceptionGroup[ValueError])
 
 # expected type error when passing a BaseException to ExceptionGroup
-ExceptionGroup("", (KeyboardInterrupt(),))  # type: ignore
+ExceptionGroup("", (KeyboardInterrupt(),))  # type: ignore[type-var]
 
 
 # code snippets from the README

--- a/tests/type_test.py
+++ b/tests/type_test.py
@@ -1,0 +1,34 @@
+from typing_extensions import assert_type
+
+from exceptiongroup import BaseExceptionGroup, ExceptionGroup, catch, suppress
+
+# issue 117
+a = BaseExceptionGroup("", (KeyboardInterrupt(),))
+assert_type(a, BaseExceptionGroup[KeyboardInterrupt])
+b = BaseExceptionGroup("", (ValueError(),))
+assert_type(b, BaseExceptionGroup[ValueError])
+c = ExceptionGroup("", (ValueError(),))
+assert_type(c, ExceptionGroup[ValueError])
+
+# expected type error when passing a BaseException to ExceptionGroup
+ExceptionGroup("", (KeyboardInterrupt(),))  # type: ignore
+
+
+# code snippets from the README
+
+def value_key_err_handler(excgroup: BaseExceptionGroup) -> None:
+    for exc in excgroup.exceptions:
+        print('Caught exception:', type(exc))
+
+def runtime_err_handler(exc: BaseExceptionGroup) -> None:
+    print('Caught runtime error')
+
+with catch({
+    (ValueError, KeyError): value_key_err_handler,
+    RuntimeError: runtime_err_handler
+}):
+    ...
+
+
+with suppress(RuntimeError):
+    raise ExceptionGroup("", [RuntimeError("boo")])

--- a/tests/type_test.py
+++ b/tests/type_test.py
@@ -16,17 +16,19 @@ ExceptionGroup("", (KeyboardInterrupt(),))  # type: ignore
 
 # code snippets from the README
 
+
 def value_key_err_handler(excgroup: BaseExceptionGroup) -> None:
     for exc in excgroup.exceptions:
-        print('Caught exception:', type(exc))
+        print("Caught exception:", type(exc))
+
 
 def runtime_err_handler(exc: BaseExceptionGroup) -> None:
-    print('Caught runtime error')
+    print("Caught runtime error")
 
-with catch({
-    (ValueError, KeyError): value_key_err_handler,
-    RuntimeError: runtime_err_handler
-}):
+
+with catch(
+    {(ValueError, KeyError): value_key_err_handler, RuntimeError: runtime_err_handler}
+):
     ...
 
 


### PR DESCRIPTION
* Fixes #117 
* Adds `tests/type_test.py` as type test, which quickly alerted me to two additional errors I also fixed:
* The cause of #117 wasn't isolated to `BaseExceptionGroup` and `ExceptionGroup` was also lacking `type[...]`, but instead of getting an error at creation it instead returning `ExceptionGroup[Unknown]`.
  * Both of these were introduced by me in #101
* `suppress` was typed as expecting instances of `BaseException`, but README was passing a class. I went with assuming the README was correct and it should only accept exception classes, but maybe it should accept either?
* I also added a random `cast` to `suppress.__exit__` so that file now type checks, though the code isn't type checked in CI so /shrug.


The type test could be much more thorough, and given that I almost instantly found an unrelated error with `suppress` I suspect there could be more issues hidden. You should definitely add repro's of any other issues you have, and I might check them out and see if they have easy fixes.