### PR TITLE
add BaseExceptionGroup.__init__, following CPython

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ This library adheres to `Semantic Versioning 2.0 <http://semver.org/>`_.
   types to define defaults for their generic arguments (defaulting to
   ``BaseExceptionGroup[BaseException]`` and ``ExceptionGroup[Exception]``)
   (PR by @mikenerone)
+- Changed ``BaseExceptionGroup.__init__()`` to directly call
+  ``BaseException.__init__()`` instead of the superclass ``__init__()`` in order to
+  emulate the CPython behavior (broken or not) (PR by @cfbolz)
 
 **1.2.2**
 

--- a/src/exceptiongroup/_exceptions.py
+++ b/src/exceptiongroup/_exceptions.py
@@ -97,6 +97,9 @@ class BaseExceptionGroup(BaseException, Generic[_BaseExceptionT_co]):
         instance._exceptions = __exceptions
         return instance
 
+    def __init__(self, *args):
+        BaseException.__init__(self, *args)
+
     def add_note(self, note: str) -> None:
         if not isinstance(note, str):
             raise TypeError(

--- a/src/exceptiongroup/_exceptions.py
+++ b/src/exceptiongroup/_exceptions.py
@@ -97,8 +97,13 @@ class BaseExceptionGroup(BaseException, Generic[_BaseExceptionT_co]):
         instance._exceptions = __exceptions
         return instance
 
-    def __init__(self, *args):
-        BaseException.__init__(self, *args)
+    def __init__(
+        self,
+        __message: str,
+        __exceptions: Sequence[_BaseExceptionT_co],
+        *args: object,
+    ) -> None:
+        BaseException.__init__(self, __message, __exceptions, *args)
 
     def add_note(self, note: str) -> None:
         if not isinstance(note, str):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -856,7 +856,7 @@ def test_bug_exceptiongroup_has_no_init():
 
         class MyException(Exception):
             def __init__(self, message):
-                assert 0, "should not be reached"
+                pytest.fail("should not be reached")
 
         class MyExceptionGroup(base, MyException):
             pass

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -847,13 +847,20 @@ def test_repr():
 
 
 def test_bug_exceptiongroup_has_no_init():
-    assert BaseExceptionGroup.__init__ is ExceptionGroup.__init__ is not BaseException.__init__
+    assert (
+        BaseExceptionGroup.__init__
+        is ExceptionGroup.__init__
+        is not BaseException.__init__
+    )
     for base in [BaseExceptionGroup, ExceptionGroup]:
+
         class MyException(Exception):
             def __init__(self, message):
-                assert 0, 'should not be reached'
+                assert 0, "should not be reached"
 
         class MyExceptionGroup(base, MyException):
             pass
 
-        MyExceptionGroup('...', [Exception()]) # does not try to call MyException.__init__
+        MyExceptionGroup(
+            "...", [Exception()]
+        )  # does not try to call MyException.__init__

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -844,3 +844,16 @@ def test_repr():
 
     group = ExceptionGroup("foo", [ValueError(1), RuntimeError("bar")])
     assert repr(group) == "ExceptionGroup('foo', [ValueError(1), RuntimeError('bar')])"
+
+
+def test_bug_exceptiongroup_has_no_init():
+    assert BaseExceptionGroup.__init__ is ExceptionGroup.__init__ is not BaseException.__init__
+    for base in [BaseExceptionGroup, ExceptionGroup]:
+        class MyException(Exception):
+            def __init__(self, message):
+                assert 0, 'should not be reached'
+
+        class MyExceptionGroup(base, MyException):
+            pass
+
+        MyExceptionGroup('...', [Exception()]) # does not try to call MyException.__init__


### PR DESCRIPTION
This was reported to PyPy as an incompatibility in this issue: https://github.com/pypy/pypy/issues/5218

CPython's BaseExceptionGroup.__init__ looks like this:

```c
static int
BaseExceptionGroup_init(PyObject *self, PyObject *args, PyObject *kwds)
{
    if (!_PyArg_NoKeywords(Py_TYPE(self)->tp_name, kwds)) {
        return -1;
    }
    if (BaseException_init(self, args, kwds) == -1) {
        return -1;
    }
    return 0;
}
```